### PR TITLE
fix+feat: 装飾の可読性是正 と El Lissitzky 3D（Proun）化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,11 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "tailwindcss": "^3.4.17",
+        "three": "^0.180.0",
         "typescript": "^5.7.3"
+      },
+      "devDependencies": {
+        "@types/three": "^0.180.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -592,6 +596,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.3",
@@ -2124,6 +2135,13 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2233,10 +2251,40 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
@@ -2354,6 +2402,13 @@
       "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
       "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
       "license": "MIT"
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
+      "integrity": "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -3572,6 +3627,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4455,6 +4517,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -6336,6 +6405,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "tailwindcss": "^3.4.17",
+    "three": "^0.180.0",
     "typescript": "^5.7.3"
+  },
+  "devDependencies": {
+    "@types/three": "^0.180.0"
   }
 }

--- a/prototypes/proun-3d-axonometric.html
+++ b/prototypes/proun-3d-axonometric.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>3D Proun 軸測構図プロトタイプ（El Lissitzky）</title>
+<!--
+  目的: designer → frontend(Three.js) 受け渡し用の軽量プロトタイプ（依存なし・SVG）。
+  El Lissitzky / Proun の「軸測投影（消失点なし）・上下の概念なし・少数の幾何形が
+  負空間に浮遊・赤い楔のアクセント」を、Three.js を使わず SVG の等角投影で図解する。
+  - これは仕様の図解であって本番実装ではない（実装は src/ で frontend が Three.js で行う）。
+  - 本図は OrthographicCamera で見たときの「初期姿勢のスナップショット」を意図する。
+  - 配置の意図: 本文（左の極大 H1）の背後を空け、Proun を右上〜中央右に寄せて重心をずらす。
+    左下に diagonal の楔で対角の力線。reduced-motion 時はこの静止図がフォールバックの基準。
+  パレット: red #D62828 / black #1A1A1A / cream #F5F0EB / gray #8B8680 / darkgray #3D3A37 のみ。
+-->
+<style>
+  :root {
+    --red:#D62828; --black:#1A1A1A; --cream:#F5F0EB; --gray:#8B8680; --darkgray:#3D3A37;
+  }
+  * { box-sizing:border-box; margin:0; }
+  body { background:#0d0d0d; color:var(--cream); font-family:Inter,system-ui,sans-serif; padding:24px; }
+  h2 { font-size:14px; letter-spacing:.25em; text-transform:uppercase; color:var(--gray); margin-bottom:12px; }
+  .stage { position:relative; width:100%; max-width:1100px; aspect-ratio:14/7; background:var(--black); margin:0 auto 28px; overflow:hidden; }
+  .stage svg { position:absolute; inset:0; width:100%; height:100%; }
+  /* 本文カラム（z上）— 実際は AnimatedHero。Proun が背後に来ても読めることを確認するため重ねる */
+  .text { position:absolute; left:4%; top:16%; right:42%; z-index:2; }
+  .label { color:var(--cream); font-size:12px; letter-spacing:.3em; text-transform:uppercase; display:flex; gap:10px; align-items:center; }
+  .label .rule { width:32px; height:2px; background:var(--red); }
+  .h1 { font-family:'Bebas Neue',Impact,sans-serif; font-size:clamp(40px,10vw,140px); line-height:.85; letter-spacing:-.02em; color:var(--cream); margin:.1em 0; }
+  .role { display:inline-flex; align-items:center; }
+  .wedge { width:0;height:0;border-top:14px solid transparent;border-bottom:14px solid transparent;border-left:20px solid var(--red); }
+  .band { background:var(--red); color:var(--cream); padding:6px 16px; font-family:'Bebas Neue',Impact,sans-serif; letter-spacing:.2em; font-size:clamp(14px,2.4vw,26px); }
+  .desc { color:var(--cream); font-size:14px; line-height:1.6; max-width:320px; margin-top:14px; border-left:2px solid var(--red); padding-left:14px; }
+  .avatar { position:absolute; right:5%; top:48%; width:18%; aspect-ratio:1; background:var(--gray); z-index:2; outline:4px solid var(--red); outline-offset:8px; }
+  .annot { color:var(--gray); font-size:12.5px; line-height:1.75; max-width:1100px; margin:0 auto; }
+  .annot b { color:var(--cream); }
+  .annot li { margin-bottom:4px; }
+  code { color:#e8a; font-family:'JetBrains Mono',monospace; font-size:.92em; }
+  .legend { display:flex; gap:18px; flex-wrap:wrap; max-width:1100px; margin:0 auto 16px; font-size:12px; color:var(--gray); }
+  .legend span { display:inline-flex; align-items:center; gap:6px; }
+  .sw { width:14px; height:14px; display:inline-block; }
+</style>
+</head>
+<body>
+  <h2>3D Proun 軸測構図プロトタイプ — 消失点なし / 浮遊する幾何形 / 赤い楔</h2>
+
+  <div class="legend" aria-hidden="true">
+    <span><i class="sw" style="background:var(--red)"></i>red #D62828 — 主役の楔・薄面</span>
+    <span><i class="sw" style="background:var(--darkgray)"></i>darkgray #3D3A37 — 陰面（同一立体の暗い側）</span>
+    <span><i class="sw" style="background:var(--cream)"></i>cream #F5F0EB — 細い棒・輪郭円（抑制）</span>
+    <span><i class="sw" style="border:1px solid var(--gray)"></i>black #1A1A1A — 背景の負空間（主役）</span>
+  </div>
+
+  <div class="stage">
+    <!--
+      等角投影 SVG（軸測の図解）。Three.js では OrthographicCamera + isometric 角度に対応。
+      X 右下方向 (1,0.5)、Y 右上方向(? ここでは簡略に画面座標で配置)。
+      立体は「明面=本来の色 / 暗面=darkgray もしくは black寄り」で軸測の陰影を表現（光源1灯の方向性）。
+      消失点はない（全ての平行線は平行のまま）。
+    -->
+    <svg viewBox="0 0 1400 700" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+      <!-- ===== 負空間（背景）= 主役。何も描かない黒の海を中央〜左下に大きく残す ===== -->
+
+      <!-- (A) 薄い大スラブ（cream 面）— 中央右に傾いて浮遊。Proun の「平面と空間の緊張」の核。
+           軸測なので長方形は平行四辺形で表現。明面 cream / 側面 darkgray。 -->
+      <g opacity="0.92">
+        <!-- 上面（明） -->
+        <polygon points="900,150 1180,210 1090,330 810,270" fill="#F5F0EB" opacity="0.16"/>
+        <!-- 薄い厚み（側面・暗） -->
+        <polygon points="810,270 1090,330 1090,348 810,288" fill="#3D3A37" opacity="0.5"/>
+      </g>
+
+      <!-- (B) 赤い楔（三角柱）= アクセント。「赤い楔で白を撃て」。
+           中央右のスラブ(A)へ左上から切り込む対角の動勢。明面 red / 側面 darkgray。 -->
+      <g>
+        <!-- 楔の上面（明・赤） -->
+        <polygon points="640,360 980,250 1010,300 670,410" fill="#D62828"/>
+        <!-- 楔の側面（暗） -->
+        <polygon points="640,360 670,410 670,430 640,380" fill="#3D3A37"/>
+        <polygon points="670,410 1010,300 1010,320 670,430" fill="#3D3A37"/>
+      </g>
+
+      <!-- (C) 細長い棒（直方体・cream）= 線的要素。左下→右上の力線。明面 cream / 側面 darkgray。 -->
+      <g>
+        <polygon points="250,560 760,400 778,430 268,590" fill="#F5F0EB" opacity="0.8"/>
+        <polygon points="268,590 778,430 778,452 268,612" fill="#3D3A37" opacity="0.8"/>
+      </g>
+
+      <!-- (D) 黒い正方板（対の重み）= 二正方形の「黒」。右上、赤の対。負空間に半ば溶ける。 -->
+      <g opacity="0.95">
+        <polygon points="1080,120 1230,150 1180,250 1030,220" fill="#1A1A1A"/>
+        <polygon points="1080,120 1230,150 1230,156 1080,126" fill="#3D3A37"/>
+        <!-- 輪郭を cream の細線で（軸測のエッジを立てる・抑制） -->
+        <polygon points="1080,120 1230,150 1180,250 1030,220" fill="none" stroke="#F5F0EB" stroke-width="1.2" opacity="0.5"/>
+      </g>
+
+      <!-- (E) 円盤（薄い円柱・red 輪郭）= 運動。空間に立つ薄い円。中央右やや上。 -->
+      <g>
+        <ellipse cx="1000" cy="420" rx="78" ry="34" fill="none" stroke="#D62828" stroke-width="3" opacity="0.85"/>
+        <!-- 薄い厚み -->
+        <ellipse cx="1000" cy="430" rx="78" ry="34" fill="none" stroke="#3D3A37" stroke-width="1.5" opacity="0.6"/>
+      </g>
+
+      <!-- (F) 小さな赤い実心正方板（点景のアクセント）= リズム。左下、楔と呼応。 -->
+      <g>
+        <polygon points="360,470 430,485 408,540 338,525" fill="#D62828" opacity="0.9"/>
+      </g>
+
+      <!-- (G) 極細の cream 棒（縦に近い斜め）= 負空間を区切る一本の線。右端。 -->
+      <polygon points="1280,90 1296,96 1230,420 1214,414" fill="#F5F0EB" opacity="0.3"/>
+    </svg>
+
+    <!-- 本文（AnimatedHero 相当・z上）— Proun が背後でも H1 が読めることを確認 -->
+    <div class="text">
+      <div class="label"><span class="rule"></span>Software Engineer — Sapporo, Japan</div>
+      <div class="h1">H.NIGO</div>
+      <div class="role"><span class="wedge"></span><span class="band">SOFTWARE ENGINEER</span></div>
+      <div class="desc">低レイヤーからアプリケーションまで。C/C++, TypeScript, Python を使い、AI ツールを活用してものづくりをしています。</div>
+    </div>
+    <div class="avatar" aria-hidden="true"></div>
+  </div>
+
+  <p class="annot">
+    <b>El Lissitzky / Proun に忠実な設計根拠:</b>
+  </p>
+  <ul class="annot">
+    <li><b>軸測投影（消失点なし）:</b> Three.js は必ず <code>OrthographicCamera</code>。PerspectiveCamera は不可。平行線は平行のまま。</li>
+    <li><b>上下の概念なし:</b> 立体はグリッド床に「立つ」のではなく負空間に浮遊。重力が曖昧。極ゆっくりの多軸ドリフトで浮遊感。</li>
+    <li><b>負空間が主役:</b> 中央〜左下の黒の海（本文 H1 の背後）を大きく空ける。少数の要素・大きな余白。</li>
+    <li><b>赤い楔のアクセント (B):</b> 「赤い楔で白を撃て」。赤の三角柱が cream スラブ(A)へ対角に切り込む動勢が構図の核。</li>
+    <li><b>二正方形の対:</b> 赤の楔/赤板(F) と 黒板(D) が赤黒の拮抗を作る。サイトの既存語彙（赤四角・黒四角）と一致。</li>
+    <li><b>軸測の陰影:</b> 各立体は明面（本来色）＋暗面（<code>darkgray #3D3A37</code>）で1灯の方向光を表現。マット（光沢なし）。</li>
+  </ul>
+  <p class="annot" style="margin-top:10px;">
+    <b>本文非干渉:</b> 左4%〜右42%（極大 H1・赤帯）の背後には立体を置かない。Proun は右上〜中央右に重心を寄せ、
+    avatar（右中）とも別重心。<b>不透明度:</b> レイヤー全体を <code>0.5</code> 前後まで後退（背景 canvas の hero opacity と同等思想）。<br>
+    <b>注:</b> 本図は等角 SVG による図解。実座標・カメラ角・速度は <code>specs/components/proun-3d.spec.md</code> と frontend の Three.js 実装で確定する。
+  </p>
+</body>
+</html>

--- a/specs/components/decoration.spec.md
+++ b/specs/components/decoration.spec.md
@@ -121,11 +121,18 @@ Tiled (.tmx / .tsx)  ──export──▶  public/tilemaps/*.json (+ tileset pn
 
 ## Hero 変奏のデザイン指針（第一印象 ＝ 赤の主役性と対角の力線）
 
+> **⚠ 更新（3D Proun 導入）**: Hero の背面 2D タイル装飾（`ConstructivistCanvas section="hero"`）は
+> **El Lissitzky の軸測 3D Proun レイヤーへ置換**する方針に決定（正典: `specs/components/proun-3d.spec.md`）。
+> 以下の「装飾タイルの主役性（canvas）」「hero seed の構図調整」節は **2D タイルを維持する場合の指針**として残すが、
+> 3D へ置換した場合は `proun-3d.spec.md` が Hero 背面の正典になる。本文（AnimatedHero）の
+> **タイポ階層・構図・余白・コントラスト・モーション**に関する指針（下記）は **3D 置換後も有効**で、
+> 3D Proun は本文の同じ「二正方形・赤い楔・対角の力線」の語彙を 3D で反復する。
+
 > 対象: `src/pages/index.astro` の最初の `section`（暗背景 `bg-constructivist-black` / `min-h-[90vh]`）、
 > `src/components/AnimatedHero.tsx`、`src/components/phaser/sections.ts` の `hero` 設定、
 > `assets/tiled/gen-tilemaps.mjs` の `hero(d)` seed、`public/tilemaps/hero.json`。
 > Hero はサイトの「掴み」。3 秒以内に「構成主義 × ソフトウェアエンジニア H.NIGO」を視覚で言い切る。
-> 構図プロトタイプ: `prototypes/hero-composition.html`（依存なし・図解用）。
+> 構図プロトタイプ: `prototypes/hero-composition.html`（2D 版）、`prototypes/proun-3d-axonometric.html`（3D 版・依存なし・図解用）。
 
 ### 第一印象の設計原則（エル・リシツキー「About Two Squares」の対）
 
@@ -167,6 +174,8 @@ Hero は **赤い正方形（主役）と黒い正方形（対の重み）が対
 
 ### 装飾タイルの主役性（canvas — sections.ts / seed）
 
+> ※ この節は **2D タイル装飾を維持する場合**の指針。3D Proun へ置換した場合は `proun-3d.spec.md` を参照。
+
 Hero タイル装飾は「掴み」の一部。本文の Proun コンポジションと**同じ二正方形の語彙**を背後で反復し、
 画面全体に構成主義の密度を与える。ただし**本文（極大 H1・赤帯・avatar）が主役**であり、装飾は増幅役。
 
@@ -189,6 +198,8 @@ Hero タイル装飾は「掴み」の一部。本文の Proun コンポジシ�
   （エージェントが組み替えても骨格が崩れない）を重視。
 
 ### hero seed の構図調整（gen-tilemaps.mjs — 対角＋本文回避）
+
+> ※ この節は **2D タイル装飾を維持する場合**の指針。3D Proun へ置換した場合は `proun-3d.spec.md` を参照。
 
 現状の seed は赤正方形が `(2,1)` と `(9,1)` でほぼ左右対称に並び、**対角の力線が弱く・本文カラム左側
 （col 2 付近）に赤正方形が乗って H1 と干渉**しやすい。第一印象の骨格として以下に組み替える方針（14×7 グリッド）:
@@ -387,6 +398,8 @@ public/decoration-fallback/
 - **置換範囲**: `ParallaxDecorations` は段階置換中の**併存のみ許容**。最終的に
   Phaser パネルへ寄せる。Contact など「静」のセクションは Phaser でも CSS でも可
   （実装フェーズ 5〜6 で軽さを見て判断）。
+- **Hero 背面の 3D 化**: Hero に限り 2D タイルを **El Lissitzky 軸測 3D Proun** へ置換（`specs/components/proun-3d.spec.md`）。
+  他セクションは 2D タイルを維持。3D は Hero のみの showpiece。
 
 ## 次サイクル（実装フェーズで検証する論点）
 

--- a/specs/components/proun-3d.spec.md
+++ b/specs/components/proun-3d.spec.md
@@ -1,0 +1,207 @@
+# 3D Proun 装飾レイヤー（Three.js / 軸測）コンポーネント仕様
+
+> ステータス: **実装済み（チューニング継続）** — `src/components/ProunCanvas.tsx`。
+>
+> 実装メモ（設計からの確定的な逸脱）:
+> - **マテリアルは `MeshBasicMaterial`（平面フラット色）を採用**（spec 案の Lambert は陰面が灰色化し
+>   cream が濁ったため）。El Lissitzky のポスター的平面性に合致。立体は軸測＋オーバーラップ＋稜線で読ませる。
+>   黒い面は cream 稜線（`EdgesGeometry`）で暗背景に見せる。
+> - **モバイル（< md / 768px）は装飾を出さない**（`hidden md:block`。three も読み込まない）。
+>   縦積みの本文に背面装飾が重なり可読性を損なうため、spec の「モバイルは静的 SVG 可」をさらに進めて非表示に。
+>   → Proun は**デスクトップ限定の showpiece**。
+> - Hero の `AnimatedHero` が持っていた 2D Proun（赤ブロック＋円＋黒ブロック）は**削除**し、装飾を 3D に一本化。
+> - レイヤー不透明度は 0.55→**0.95**（下げると cream が黒地に溶け灰色化するため。後退はマテリアル opacity と配置で担保）。
+> 本書は「El Lissitzky / Proun を本気で吟味した Hero の 3D 背面装飾」の設計合意。
+> 構図プロトタイプ（依存なし・SVG 軸測図解）: `prototypes/proun-3d-axonometric.html`。
+> 既存 2D タイル装飾の基準: `specs/components/decoration.spec.md`（Hero 変奏節）。
+
+## 目的
+
+Hero（暗背景 `bg-constructivist-black` / `min-h-[90vh]`）の背面に、**El Lissitzky の Proun
+（軸測投影・浮遊する基本幾何形・赤い楔・負空間の緊張）**を 3D で実装した showpiece 装飾を置く。
+ユーザー要望「El Lissitzky のデザインをよく吟味して実装」「3D のオブジェがあるといい」に応える。
+**本文（極大 H1「H.NIGO」・赤帯・avatar・説明文）の可読性を絶対に損なわない背面装飾**であること。
+
+---
+
+## El Lissitzky / Proun の一次調査（設計の根拠 — ぶらさない）
+
+| 原則 | Proun での意味 | 本実装への落とし込み |
+|------|---------------|--------------------|
+| **軸測投影（axonometric / orthographic）** | 透視図法ではなく平行投影。消失点なし。 | **`OrthographicCamera` 必須**。`PerspectiveCamera` は不可。 |
+| **上下の概念がない（neither top nor bottom）** | 重力が曖昧、幾何形が空間に浮遊。 | 立体は床に立たせない。負空間に浮遊。極ゆっくりの多軸ドリフト。 |
+| **3D 負空間と平面的幾何形の緊張** | 薄い面・棒・円が傾いて交差し浮かぶ。負空間（余白）が主役。 | 少数の要素・大きな余白。立体は薄いスラブ・細い棒中心。 |
+| **強い対角構造・赤い楔のアクセント** | 「赤い楔で白を撃て」。赤い楔が白い面に切り込む対角の動勢。 | 赤い三角柱（楔）が cream スラブへ対角に切り込む＝構図の核。 |
+| **最小パレット・基本幾何形** | 棒・薄面・円盤・正方形・楔・線。 | 構成主義パレット内（後述）。形は 6〜7 種に限定。 |
+
+代表作の参照: Proun 19D / 99 / Proun Room、「Beat the Whites with the Red Wedge」。
+
+---
+
+## 設計の決定事項
+
+| 軸 | 決定 | 理由 |
+|----|------|------|
+| **配置セクション** | **Hero のみ**（showpiece）。他セクションは現状の 2D タイル維持。 | 3D は重い・掴みの主役。全セクション展開は性能と煩雑さで不採用。 |
+| **Hero の 2D タイルとの関係** | **置換**（Hero では `ConstructivistCanvas section="hero"` を外し 3D に差し替え）。 | 2D タイル＋3D Proun の併存は同一ビューポートで装飾が二重化し煩雑。重心が割れる。 |
+| **Contact への展開** | 当面しない。将来検討（静のセクションなので別案件）。 | 過剰実装回避。まず Hero を成立させる。 |
+| **カメラ** | `OrthographicCamera`（軸測）。回転・ドリフトはオブジェクト側で行いカメラは固定。 | Proun の消失点なし。カメラを動かすと視差で透視感が出る。 |
+| **モーション** | 非常にゆっくりした多軸ドリフト/微回転。スクロール連動は**しない**。 | 可読性優先。スクロール連動は H1 読書を妨げる。重力の曖昧さは緩慢な浮遊で表す。 |
+| **存在感** | 低め。レイヤー不透明度 0.5 前後、本文カラム背後は空ける。 | 「気付いた人だけに伝わる」既存の装飾思想を踏襲。 |
+| **フォールバック** | reduced-motion / WebGL 非対応 → **静的 SVG 軸測 Proun**。 | 既存 2D の `StaticComposition` と同思想。3D の初期姿勢を SVG で再現。 |
+| **遅延ロード** | Three.js を動的 import（初期バンドル非搭載）。 | 既存 Phaser と同じ規律。 |
+
+---
+
+## 技術アーキテクチャ（確定・ぶらさない）
+
+- **新規 React ラッパー** `src/components/ProunCanvas.tsx`（`ConstructivistCanvas.tsx` を雛形に）。
+  Astro 側は Hero の `<ConstructivistCanvas section="hero" />` を `<ProunCanvas client:visible />` に**置換**。
+- **遅延ロード**: `client:visible` でマウント、その時点で初めて `import('three')`。初期 JS に three を載せない。
+- **オフスクリーン休止**: `IntersectionObserver` で可視外は `requestAnimationFrame` を止める（rAF ループを停止）。
+- **WebGL レンダラ**: `WebGLRenderer({ antialias: true, alpha: true })`。背景は透明（下の `bg-constructivist-black` を活かす）。
+- **DPR 上限**: `renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))`（モバイルのバッテリ保護）。
+- **ライト**: `AmbientLight`（地）＋ `DirectionalLight` 1 灯（軸測の方向性陰影を与える）。多灯にしない。
+- **マテリアル**: `MeshLambertMaterial`（マット・光沢なし）。`MeshStandardMaterial` の metalness/roughness は不要（Proun はマット）。
+- **A11y**: ラッパー `div` は `aria-hidden="true"`、`pointer-events:none`。**スクロール・操作を一切奪わない**。
+
+### カメラ（OrthographicCamera）パラメータ方針
+
+```
+frustumSize ≈ 10（シーンの「世界単位」基準。下記オブジェクト寸法はこの単位）
+aspect = width / height
+camera = new OrthographicCamera(
+  -frustumSize*aspect/2,  frustumSize*aspect/2,
+   frustumSize/2,        -frustumSize/2,
+   0.1, 100 )
+camera.position.set(8, 6, 8)   // 等角に近い斜め俯瞰（isometric寄り）
+camera.lookAt(0, 0, 0)
+```
+
+- リサイズ時は `left/right/top/bottom` を aspect で更新し `updateProjectionMatrix()`。
+- カメラは固定。視点を変えない（軸測の一貫性 ＝ 消失点なしを保つ）。
+
+---
+
+## シーン構成 — 浮遊する Proun オブジェクト（具体リスト）
+
+> 世界単位は frustumSize=10 基準。座標 (x,y,z)。**右上〜中央右に重心**を寄せ、左下に楔の力線。
+> **本文カラム（画面左〜中央上、極大 H1・赤帯）の背後は空ける** ＝ オブジェクトを画面左 1/3 上部に置かない。
+> 数は **6〜7 個**に厳守（少数の要素・大きな余白）。色は `constructivist.*` のみ。
+
+| # | 役割 | 形（Three.js geometry） | 寸法比 | 色（マテリアル color） | 初期姿勢（傾き） | 配置の意図 |
+|---|------|------------------------|--------|----------------------|-----------------|-----------|
+| A | 薄い大スラブ（cream 面） | `BoxGeometry` 薄板 | 4 × 0.12 × 2.6 | `#F5F0EB`（cream・不透明度 0.85） | rotate ~ (12°, 20°, -8°) | 平面と空間の緊張の核。中央右に浮遊。 |
+| B | **赤い楔（アクセント）** | `CylinderGeometry`（radialSegments=3）または三角柱の `ExtrudeGeometry` | 高さ 0.4 / 断面 2.2 | `#D62828`（red） | スラブ A へ左上から対角に切り込む向き | 「赤い楔で白を撃て」。**構図の主役の動勢**。 |
+| C | 細長い棒（直方体・cream） | `BoxGeometry` | 5 × 0.18 × 0.18 | `#F5F0EB`（cream・不透明度 0.7） | 左下→右上の対角（roll ~ -30°） | 線的力線。負空間を貫く。 |
+| D | 黒い正方板（対の重み） | `BoxGeometry` 薄板 | 1.8 × 0.12 × 1.8 | `#1A1A1A`（black）＋ cream 細エッジ線（任意） | rotate ~ (-10°, 30°, 5°) | 二正方形の「黒」。赤の対。右上。負空間に半ば溶ける。 |
+| E | 薄い円盤（red 輪郭） | `TorusGeometry`（太さ細）または `RingGeometry` の薄い円柱 | 半径 1.1 / 太さ 0.06 | `#D62828`（red） | 空間に立つ（面が斜め）| 運動。中央右やや上。 |
+| F | 小さな赤い実心正方板 | `BoxGeometry` 小 | 0.7 × 0.1 × 0.7 | `#D62828`（red） | 楕 B と呼応する傾き | 左下のリズムの点景。楔と赤で呼応。 |
+| G | 極細の cream 棒（任意・7個目） | `BoxGeometry` 極細 | 0.08 × 3.4 × 0.08 | `#F5F0EB`（cream・不透明度 0.3） | ほぼ縦のわずかな斜め | 右端で負空間を区切る一本の線。 |
+
+- **darkgray `#3D3A37` の用途**: 各立体の陰面（DirectionalLight が当たらない側）に**自然に現れる**陰影として使う。
+  独立した立体に darkgray を割り当てるのではなく、ライティングで明面（本来色）と暗面（暗くなった面）を出す。
+- **角丸なし**: ベベル/フィレットは付けない。シャープエッジ厳守。
+- **マット**: `MeshLambertMaterial`。鏡面ハイライトを出さない。
+
+---
+
+## モーション仕様（重力の曖昧さ ＝ 緩慢な浮遊）
+
+- **多軸ドリフト/微回転**: 各オブジェクトを**非常にゆっくり**回す。`prefers-reduced-motion` 非該当時のみ。
+  - 回転速度の目安: 各軸 **0.02〜0.06 rad/秒**（= 1 回転に 100〜300 秒）。過剰回転は厳禁。
+  - 全オブジェクトを同期させない。各々わずかに異なる速度・軸で「漂う」非周期感を出す。
+  - 任意で `position.y` を **±0.15 単位**の極めて浅い sin 揺れ（周期 12〜24 秒）で浮遊感を補強。
+- **スクロール連動はしない**: H1 の読書を妨げる。Hero 内で完結する自律アニメのみ。
+- **初期演出（任意）**: マウント時に各オブジェクトが最終姿勢へ静かにフェード/イーズイン（1 回・1〜1.5 秒）。
+  これも reduced-motion 時は無効（最終姿勢を即時表示）。
+- **fps**: 30〜60 で頭打ち。ドリフトが緩慢なので 30fps でも視覚的に滑らか。低性能端末では 30fps に間引いてよい。
+- **reduced-motion 時**: rAF を回さず**静的フォールバック（SVG 軸測 Proun）**を出す（後述）。
+
+---
+
+## 可読性との両立（本文非干渉 — 最優先）
+
+- **本文カラム背後を空ける**: 画面左〜中央上（極大 H1「H.NIGO」・赤帯 SOFTWARE ENGINEER の背後 ≒ 画面の左 45%・上 60%）には
+  立体を置かない。Proun の重心は**右上〜中央右**（オブジェクト A/D/E/G）と**左下の楔の力線**（B/C/F は中央右〜左下を斜めに走るが、
+  本文ブロックの直背後 ＝ 左上 1/3 には侵入させない）。
+- **avatar（右中）と別重心**: AnimatedHero の avatar は右中にある。Proun の右上重心（A/D）と avatar の間に**余白の谷**を残す。
+- **レイヤー不透明度**: 装飾全体を後退させる。canvas（または renderer の出力）を `opacity: 0.5` 前後で表示
+  （既存 hero タイルの `opacity 0.5` と同等思想）。red の楔だけは構図の主役なので、レイヤー不透明度内で**最も視認される**配置にする。
+- **被写界（任意）**: 軸測なので被写界深度（DOF）は使わない（透視感が出る）。代わりに**遠い要素ほど不透明度を下げる**手で奥行きを抑制してよい。
+- **z-index**: Proun レイヤーは本文（`relative z-10`）より下層（`absolute inset-0`、z-0）。
+
+### 配色・コントラスト（暗背景 #1A1A1A 上 / a11y）
+
+- 装飾図形は**非テキスト・グラフィカル要素 ＝ 3:1 で十分**。本実装はテキストを一切含まない（aria-hidden）。
+  - red `#D62828` on black ≒ **3.48:1** — 装飾として OK。赤い楔を主役にできる。
+  - cream `#F5F0EB` on black ≒ **15.4:1** — 非常に明るい。**極大 cream H1 と競合**するため、cream のスラブ/棒は
+    **不透明度を抑え（0.3〜0.85）、本文カラム背後に置かない**。これで H1 と混同しない。
+  - darkgray `#3D3A37` — 陰面に使う。暗背景に沈むので本文を邪魔しない。
+- **本文テキストのコントラストは装飾が背後で下げてはならない**: 本文は z-10 で上層、Proun は半透明で下層。
+  H1（cream・極大）・赤帯（cream on red ≒ 4.42:1）・説明文（gray on black ≒ 4.82:1）はいずれも装飾と独立して AA を維持。
+
+---
+
+## フォールバック仕様
+
+- **判定**: `prefers-reduced-motion: reduce`（`matchMedia`）または **WebGL 非対応**で 3D を起動せず静的表示。
+- **静的フォールバック**: **SVG 軸測 Proun**（`prototypes/proun-3d-axonometric.html` の SVG を基準に
+  `public/decoration-fallback/proun-hero.svg` を用意、または ProunCanvas 内でインライン SVG を描画）。
+  - フォールバックでも「**赤い楔が cream スラブへ対角に切り込む / 右上の黒板 / 左下→右上の cream 棒の力線**」の
+    Proun 構図が**静止で読める**こと。
+  - SVG は等角投影（消失点なし）で 3D の初期姿勢を再現。色は constructivist パレットのみ。
+- **WebGL フォールバック分岐**は既存 `ConstructivistCanvas` の `supportsWebGL()` をそのまま流用してよい。
+
+---
+
+## 性能上限の方針（モバイル配慮）
+
+- **ポリゴン数**: 全オブジェクト合計で **数百〜2,000 三角形以内**。Box/Cylinder/Torus の低 segment で十分
+  （Torus は radialSegments=8〜12, tubularSegments=24 程度）。重いジオメトリ・大量メッシュは不要（Proun は少数の要素）。
+- **ライト**: AmbientLight 1 ＋ DirectionalLight 1 のみ。シャドウマップは**使わない**（コスト高・軸測の意匠に不要）。
+- **DPR**: `min(devicePixelRatio, 2)`。
+- **休止**: 可視外で rAF 停止。タブ非アクティブ（`visibilitychange`）でも停止。
+- **モバイル**: 幅 < 480px ではオブジェクト数を **5 個に間引く**（G・F を落とす等）か、frustumSize を上げて全体を縮め余白を増やす。
+  もしくはモバイルでは最初から静的 SVG フォールバックにしてもよい（性能優先。frontend が実機で判断）。
+- **メモリ解放**: アンマウント時に geometry/material を `dispose()`、renderer を `dispose()`、canvas を除去。
+
+---
+
+## デザイン指針（まとめ）
+
+- **軸測（OrthographicCamera）・消失点なし**を厳守。透視カメラは使わない。
+- **少数の要素（6〜7）・大きな負空間**。語彙を増やさず、配色・傾き・配置で Proun を表現。
+- **赤い楔の対角の動勢**を構図の核に。二正方形（赤・黒）の拮抗を 3D で反復。
+- **マット・シャープエッジ・角丸なし**。光沢/ベベルを出さない。
+- **背面・低存在感**。本文カラム背後を空け、不透明度で後退。H1 と重心をずらす。
+- パレット外の色を導入しない（新色が要るなら本 spec に理由とトークン追加案を先に書く）。
+
+---
+
+## frontend 受け渡しチェックリスト（実装の入口）
+
+- [ ] Hero の `<ConstructivistCanvas section="hero" />` を `<ProunCanvas client:visible />` に置換（他セクションの 2D タイルは維持）。
+- [ ] `three` を動的 import（初期バンドル非搭載）。`OrthographicCamera`（透視カメラ不可）。
+- [ ] オブジェクト A〜G を上表の形・寸法比・色・傾きで配置。重心を右上〜中央右に、楔の力線を左下に。本文カラム背後（左上 1/3）は空ける。
+- [ ] AmbientLight + DirectionalLight 1 灯、`MeshLambertMaterial`（マット）。陰面に darkgray が自然に出る。
+- [ ] 多軸ドリフト 0.02〜0.06 rad/s（過剰回転禁止）。スクロール連動なし。`prefers-reduced-motion` で rAF を回さず静的 SVG。
+- [ ] WebGL 非対応 / reduced-motion → SVG 軸測 Proun フォールバック（`prototypes/proun-3d-axonometric.html` 基準）。
+- [ ] DPR ≤ 2、シャドウなし、ポリゴン ≤ 2,000、可視外/タブ非表示で rAF 停止、アンマウントで dispose。
+- [ ] ラッパーは `aria-hidden` / `pointer-events:none` / z-0、レイヤー不透明度 0.5 前後。
+
+---
+
+## 受入条件
+
+- [ ] Hero 背面に軸測（消失点なし）の 3D Proun が表示され、赤い楔が cream スラブへ対角に切り込む動勢が読める。
+- [ ] オブジェクトは 6〜7 個・大きな負空間が保たれ、語彙過多になっていない（Proun の「少数の要素」）。
+- [ ] 極大 H1「H.NIGO」・赤帯・説明文・avatar の可読性が一切損なわれない（本文カラム背後に立体がない／レイヤー後退）。
+- [ ] 本文テキストのコントラストが AA を維持（装飾は半透明・下層でこれを下げない）。
+- [ ] モーションが緩慢な多軸ドリフトで、過剰回転・スクロール連動がない。重力の曖昧な浮遊感がある。
+- [ ] `prefers-reduced-motion: reduce` で 3D が起動せず静的 SVG Proun が表示され、同じ Proun 構図が静止で読める。
+- [ ] WebGL 非対応で静的 SVG フォールバックに分岐し破綻しない。
+- [ ] 初期 JS バンドルに `three` が含まれない（遅延ロード）。可視外で rAF が停止する。
+- [ ] DPR ≤ 2・シャドウなし・ポリゴン少数で、モバイルでも体感の重さがない。
+- [ ] 色は constructivist パレット（red/black/cream/gray/darkgray）のみ。角丸なし・マット。
+- [ ] `astro check` でエラーがない。

--- a/src/components/AnimatedHero.tsx
+++ b/src/components/AnimatedHero.tsx
@@ -33,32 +33,6 @@ export default function AnimatedHero({
     immediate: reduceMotion,
   });
 
-  // 赤い大ブロック（Proun背景）
-  const redBlockSpring = useSpring({
-    opacity: ready ? 1 : 0,
-    transform: ready ? 'scale(1) rotate(-6deg)' : 'scale(0.5) rotate(-30deg)',
-    config: { tension: 70, friction: 14 },
-    delay: 900,
-    immediate: reduceMotion,
-  });
-
-  // 黒い小ブロック
-  const blackBlockSpring = useSpring({
-    opacity: ready ? 0.9 : 0,
-    transform: ready ? 'translate(0px,0px) rotate(12deg)' : 'translate(-30px,30px) rotate(50deg)',
-    config: { tension: 80, friction: 16 },
-    delay: 1100,
-    immediate: reduceMotion,
-  });
-
-  // 輪郭円
-  const circleOpacity = useSpring({
-    opacity: ready ? 0.25 : 0,
-    config: { tension: 60, friction: 14 },
-    delay: 1300,
-    immediate: reduceMotion,
-  });
-
   // アバター
   const avatarSpring = useSpring({
     opacity: ready ? 1 : 0,
@@ -79,21 +53,7 @@ export default function AnimatedHero({
   return (
     <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 w-full py-16">
 
-      {/* Proun的な幾何学コンポジション — 右端へ寄せ、avatar と別重心に（余白の谷を作る） */}
-      <div className="absolute top-24 right-0 w-56 h-56 sm:top-0 sm:w-80 sm:h-80 pointer-events-none" aria-hidden="true">
-        <animated.div
-          style={redBlockSpring}
-          className="absolute top-4 right-0 w-36 h-36 sm:w-52 sm:h-52 bg-constructivist-red origin-center"
-        />
-        <animated.div
-          style={blackBlockSpring}
-          className="absolute top-12 right-8 w-16 h-16 sm:top-20 sm:right-12 sm:w-24 sm:h-24 bg-constructivist-black origin-center"
-        />
-        <animated.div
-          style={circleOpacity}
-          className="absolute top-0 right-0 w-28 h-28 sm:w-40 sm:h-40 rounded-full border-4 border-constructivist-cream"
-        />
-      </div>
+      {/* 右上の Proun 装飾は 3D（ProunCanvas）に一本化。ここでは重複させない。 */}
 
       <div className="flex flex-col md:flex-row items-start gap-0 md:gap-20">
 

--- a/src/components/ConstructivistCanvas.tsx
+++ b/src/components/ConstructivistCanvas.tsx
@@ -47,6 +47,8 @@ export default function ConstructivistCanvas({ section }: Props) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const [staticFallback, setStaticFallback] = useState(false);
   const [mapData, setMapData] = useState<TiledMap | null>(null);
+  // 装飾は純背景。セクション毎の不透明度で本文より確実に後退させる（可読性最優先）。
+  const layerOpacity = getSection(section).opacity;
 
   // Tiled seed マップを取得（フォールバック描画にも使う）
   useEffect(() => {
@@ -148,7 +150,8 @@ export default function ConstructivistCanvas({ section }: Props) {
       aria-hidden="true"
       className="absolute inset-0 overflow-hidden"
       // canvas はクリックを拾うがコンテンツは z-10 で上に出す。スクロールは奪わない。
-      style={{ touchAction: 'pan-y' }}
+      // opacity で装飾を背面に後退させ、本文（特に白文字）と競合させない。
+      style={{ touchAction: 'pan-y', opacity: layerOpacity }}
     >
       {staticFallback && <StaticComposition section={section} mapData={mapData} />}
     </div>
@@ -181,7 +184,7 @@ function StaticComposition({ section, mapData }: { section: string; mapData: Til
 
   return (
     <svg
-      className="w-full h-full opacity-90"
+      className="w-full h-full"
       viewBox={`0 0 ${mw} ${mh}`}
       preserveAspectRatio="xMidYMid slice"
       role="presentation"

--- a/src/components/ProunCanvas.tsx
+++ b/src/components/ProunCanvas.tsx
@@ -1,0 +1,349 @@
+import { useEffect, useRef, useState } from 'react';
+// 型のみ import（実体は遅延 import するので three は初期バンドルに載らない）
+import type * as THREE_NS from 'three';
+
+// 設計: specs/components/proun-3d.spec.md
+// El Lissitzky / Proun を 3D（軸測投影）で。Hero 背面の showpiece 装飾。
+
+const RED = 0xd62828;
+const BLACK = 0x1a1a1a;
+const CREAM = 0xf5f0eb;
+
+// レイヤー不透明度は高めに保つ（下げると cream が黒地に溶けて灰色化する）。
+// 後退は各マテリアルの opacity と「本文カラム背後を空ける」配置で担保する。
+const LAYER_OPACITY = 0.95;
+const FRUSTUM = 11;
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+function supportsWebGL(): boolean {
+  try {
+    const c = document.createElement('canvas');
+    return !!(c.getContext('webgl') || c.getContext('experimental-webgl'));
+  } catch {
+    return false;
+  }
+}
+
+interface ObjSpec {
+  id: string;
+  geom: () => THREE_NS.BufferGeometry;
+  color: number;
+  opacity: number;
+  pos: [number, number, number];
+  rot: [number, number, number]; // ラジアン
+  spin: [number, number, number]; // rad/秒（緩慢ドリフト）
+  bob: number; // y 揺れ振幅（単位）
+  edge?: number; // 稜線の色（暗背景で黒い面を見せる / 平面に定義を与える）
+  mobileDrop?: boolean; // 幅<480 で間引く
+}
+
+// 度→ラジアン
+const d = (deg: number) => (deg * Math.PI) / 180;
+
+function buildSpecs(THREE: typeof THREE_NS): ObjSpec[] {
+  return [
+    // A: 薄いスラブ（cream 面）— 平面と空間の緊張の核。傾けて「机の天板」読みを避ける
+    {
+      id: 'A-slab',
+      geom: () => new THREE.BoxGeometry(2.7, 0.09, 1.7),
+      color: CREAM,
+      opacity: 0.9,
+      pos: [1.3, 1.0, 0.2],
+      rot: [d(40), d(20), d(-24)],
+      spin: [0.006, 0.026, 0.006],
+      bob: 0.12,
+      edge: 0x3d3a37,
+    },
+    // B: 赤い楔（三角柱）— 「赤い楔で白を撃て」。構図の主役の動勢
+    {
+      id: 'B-wedge',
+      geom: () => new THREE.CylinderGeometry(1.05, 1.05, 0.4, 3),
+      color: RED,
+      opacity: 1,
+      pos: [0.1, 1.5, 0.7],
+      rot: [d(90), d(6), d(36)],
+      spin: [0.0, 0.05, 0.0],
+      bob: 0.14,
+    },
+    // C: 細長い棒（cream）— 構図を貫く一本の急な対角の力線
+    {
+      id: 'C-bar',
+      geom: () => new THREE.BoxGeometry(5.4, 0.14, 0.14),
+      color: CREAM,
+      opacity: 0.62,
+      pos: [0.7, 0.8, -0.3],
+      rot: [d(8), d(18), d(-48)],
+      spin: [0.0, 0.022, 0.01],
+      bob: 0.1,
+    },
+    // D: 黒い正方板（赤の対）— A とは別角度で独立して浮遊（"画面"読みを避ける）。cream 稜線で見せる
+    {
+      id: 'D-square',
+      geom: () => new THREE.BoxGeometry(1.5, 0.1, 1.5),
+      color: BLACK,
+      opacity: 1,
+      pos: [3.3, 2.3, -0.5],
+      rot: [d(34), d(22), d(-16)],
+      spin: [0.016, 0.02, 0.0],
+      bob: 0.14,
+      edge: CREAM,
+    },
+    // E: 薄い円盤（red 輪郭）— 運動。中央やや下に浮く
+    {
+      id: 'E-ring',
+      geom: () => new THREE.TorusGeometry(1.0, 0.05, 10, 36),
+      color: RED,
+      opacity: 1,
+      pos: [2.5, 0.1, 1.1],
+      rot: [d(66), d(12), d(0)],
+      spin: [0.028, 0.0, 0.03],
+      bob: 0.12,
+    },
+    // F: 小さな赤い実心正方板（左下のリズムの点景・楔と呼応）
+    {
+      id: 'F-dot',
+      geom: () => new THREE.BoxGeometry(0.66, 0.1, 0.66),
+      color: RED,
+      opacity: 1,
+      pos: [-1.5, -1.4, 0.8],
+      rot: [d(22), d(35), d(12)],
+      spin: [0.04, 0.04, 0.0],
+      bob: 0.1,
+      mobileDrop: true,
+    },
+    // G: 赤い極細の対角線（右下の運動の点景・楔と呼応）。縦の"柱"読みを避け斜めに
+    {
+      id: 'G-line',
+      geom: () => new THREE.BoxGeometry(2.6, 0.07, 0.07),
+      color: RED,
+      opacity: 0.9,
+      pos: [3.0, -0.9, 0.2],
+      rot: [d(0), d(20), d(-58)],
+      spin: [0.0, 0.018, 0.012],
+      bob: 0.08,
+      mobileDrop: true,
+    },
+  ];
+}
+
+export default function ProunCanvas() {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const [fallback, setFallback] = useState(false);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    // モバイルは装飾を出さない（hidden md:block）。reduced-motion/WebGL 非対応のみ静的 SVG。
+    if (host.getBoundingClientRect().width < 80) return;
+    if (prefersReducedMotion() || !supportsWebGL()) {
+      setFallback(true);
+      return;
+    }
+
+    let raf = 0;
+    let disposed = false;
+    let cleanup: (() => void) | null = null;
+
+    const run = async () => {
+      // 非表示（モバイル＝hidden md:block で width 0）では起動しない。three も読み込まない。
+      if (host.getBoundingClientRect().width < 80) return;
+      const THREE = await import('three');
+      if (disposed) return;
+
+      const rect = host.getBoundingClientRect();
+      let width = Math.max(1, Math.round(rect.width));
+      let height = Math.max(1, Math.round(rect.height));
+      const isMobile = width < 480;
+
+      const scene = new THREE.Scene();
+
+      const makeCamera = (w: number, h: number) => {
+        const aspect = w / h;
+        const cam = new THREE.OrthographicCamera(
+          (-FRUSTUM * aspect) / 2,
+          (FRUSTUM * aspect) / 2,
+          FRUSTUM / 2,
+          -FRUSTUM / 2,
+          0.1,
+          100
+        );
+        cam.position.set(8, 6, 8);
+        cam.lookAt(0, 0, 0);
+        return cam;
+      };
+      let camera = makeCamera(width, height);
+
+      const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+      renderer.setSize(width, height);
+      host.appendChild(renderer.domElement);
+
+      // El Lissitzky の Proun は平面的なポスター色（強い陰影なし）。MeshBasicMaterial で
+      // 各面を正しい単色にする（Lambert だと陰面が灰色化し cream が濁る）。ライト不要。
+      // 軸測（消失点なし）＋オーバーラップ＋傾きで立体を読ませる。
+
+      // Proun を中央右へ寄せ、本文カラム背後（左上）を空ける。
+      // scale を下げて大きな負空間（Proun の主役＝余白）を確保。
+      const group = new THREE.Group();
+      group.position.set(1.1, 0.6, 0);
+      group.scale.setScalar(0.84);
+      scene.add(group);
+
+      const geoms: THREE_NS.BufferGeometry[] = [];
+      const mats: THREE_NS.Material[] = [];
+      const meshes: Array<{ mesh: THREE_NS.Mesh; spec: ObjSpec; baseY: number }> = [];
+
+      for (const spec of buildSpecs(THREE)) {
+        if (isMobile && spec.mobileDrop) continue;
+        const geom = spec.geom();
+        const mat = new THREE.MeshBasicMaterial({
+          color: spec.color,
+          transparent: spec.opacity < 1,
+          opacity: spec.opacity,
+        });
+        const mesh = new THREE.Mesh(geom, mat);
+        mesh.position.set(...spec.pos);
+        mesh.rotation.set(...spec.rot);
+        group.add(mesh);
+        geoms.push(geom);
+        mats.push(mat);
+        // 稜線（黒い面を暗背景で見せる / シャープエッジの定義）
+        if (spec.edge !== undefined) {
+          const eg = new THREE.EdgesGeometry(geom);
+          const em = new THREE.LineBasicMaterial({
+            color: spec.edge,
+            transparent: true,
+            opacity: spec.opacity * 0.9,
+          });
+          mesh.add(new THREE.LineSegments(eg, em));
+          geoms.push(eg);
+          mats.push(em);
+        }
+        meshes.push({ mesh, spec, baseY: spec.pos[1] });
+      }
+
+      const resize = () => {
+        const r = host.getBoundingClientRect();
+        width = Math.max(1, Math.round(r.width));
+        height = Math.max(1, Math.round(r.height));
+        const aspect = width / height;
+        camera.left = (-FRUSTUM * aspect) / 2;
+        camera.right = (FRUSTUM * aspect) / 2;
+        camera.top = FRUSTUM / 2;
+        camera.bottom = -FRUSTUM / 2;
+        camera.updateProjectionMatrix();
+        renderer.setSize(width, height);
+      };
+      const ro = new ResizeObserver(resize);
+      ro.observe(host);
+
+      // 緩慢ドリフト（重力の曖昧さ）。スクロール連動なし。
+      let last = 0;
+      let elapsed = 0;
+      let running = true;
+      const tick = (t: number) => {
+        if (disposed) return;
+        raf = requestAnimationFrame(tick);
+        if (!running) return;
+        const dt = last ? Math.min((t - last) / 1000, 0.05) : 0;
+        last = t;
+        elapsed += dt;
+        for (const { mesh, spec, baseY } of meshes) {
+          mesh.rotation.x += spec.spin[0] * dt;
+          mesh.rotation.y += spec.spin[1] * dt;
+          mesh.rotation.z += spec.spin[2] * dt;
+          if (spec.bob) {
+            mesh.position.y =
+              baseY + Math.sin(elapsed * 0.4 + baseY * 1.7) * spec.bob;
+          }
+        }
+        renderer.render(scene, camera);
+      };
+      raf = requestAnimationFrame(tick);
+
+      // 可視外・タブ非アクティブで rAF を実質停止（描画スキップ）
+      const io = new IntersectionObserver(
+        (entries) => {
+          for (const e of entries) running = e.isIntersecting;
+          if (running) last = 0;
+        },
+        { threshold: 0 }
+      );
+      io.observe(host);
+      const onVis = () => {
+        running = document.visibilityState === 'visible';
+        if (running) last = 0;
+      };
+      document.addEventListener('visibilitychange', onVis);
+
+      cleanup = () => {
+        cancelAnimationFrame(raf);
+        ro.disconnect();
+        io.disconnect();
+        document.removeEventListener('visibilitychange', onVis);
+        for (const g of geoms) g.dispose();
+        for (const m of mats) m.dispose();
+        renderer.dispose();
+        if (renderer.domElement.parentNode === host) host.removeChild(renderer.domElement);
+      };
+    };
+
+    void run();
+
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(raf);
+      cleanup?.();
+    };
+  }, []);
+
+  return (
+    <div
+      ref={hostRef}
+      aria-hidden="true"
+      // モバイルでは装飾を非表示（本文の可読性最優先 / three も読まない）。md 以上で showpiece。
+      className="absolute inset-0 overflow-hidden hidden md:block"
+      style={{ opacity: LAYER_OPACITY, pointerEvents: 'none' }}
+    >
+      {fallback && <ProunFallback />}
+    </div>
+  );
+}
+
+/**
+ * reduced-motion / WebGL 非対応時の静的 SVG 軸測 Proun。
+ * 3D の初期姿勢（赤い楔が cream スラブへ対角に切り込む / 右上の黒板 / 対角の力線）を等角で再現。
+ * 3D と同じく **中央右に収め**、本文（左の H1・説明）に被せない（slice で全面に拡大しない）。
+ */
+function ProunFallback() {
+  return (
+    <svg
+      className="absolute top-1/2 right-[4%] -translate-y-1/2 w-[48%] sm:w-[44%] max-w-xl"
+      viewBox="0 0 120 92"
+      preserveAspectRatio="xMidYMid meet"
+      role="presentation"
+    >
+      {/* C: 左下→右上の cream の力線 */}
+      <polygon points="8,86 13,82 104,20 99,24" fill="#F5F0EB" opacity="0.4" />
+      {/* A: cream スラブ（軸測の平行四辺形） */}
+      <polygon points="30,44 78,31 87,55 39,68" fill="#F5F0EB" opacity="0.6" />
+      {/* B: 赤い楔がスラブへ対角に切り込む（構図の核） */}
+      <polygon points="13,41 41,54 12,62" fill="#D62828" opacity="0.92" />
+      {/* D: 黒い正方板（右上）＋ cream 稜線 */}
+      <polygon points="74,12 98,7 104,29 80,34" fill="#1A1A1A" stroke="#F5F0EB" strokeWidth="0.8" />
+      {/* E: 赤い円環（運動） */}
+      <ellipse cx="72" cy="52" rx="15" ry="7.5" fill="none" stroke="#D62828" strokeWidth="1.6" transform="rotate(-16 72 52)" opacity="0.9" />
+      {/* F: 左下の赤い小板 */}
+      <polygon points="20,71 30,67 33,77 23,81" fill="#D62828" opacity="0.9" />
+      {/* G: 右下の赤い対角線 */}
+      <polygon points="86,60 88,59 105,84 103,85" fill="#D62828" opacity="0.85" />
+    </svg>
+  );
+}

--- a/src/components/phaser/sections.ts
+++ b/src/components/phaser/sections.ts
@@ -18,6 +18,11 @@ export interface SectionConfig {
   palette: Record<ColorName, number>;
   /** 形状の出現重み（構成主義の変奏） */
   shapeWeights: Partial<Record<ShapeName, number>>;
+  /**
+   * 装飾レイヤー全体の不透明度 0..1。装飾は純背景なので本文の可読性を最優先し、
+   * 文字に埋もれない程度まで後退させる。本文が密なセクションほど低く。
+   */
+  opacity: number;
 }
 
 export type ShapeName =
@@ -48,10 +53,11 @@ export const SECTIONS: Record<string, SectionConfig> = {
   hero: {
     key: 'hero',
     background: 'dark',
-    density: 0.36,
+    density: 0.32,
     agents: 1,
     palette: { red: 0.6, black: 0.2, cream: 0.2 },
     shapeWeights: { redSquare: 4, diagonal: 3, circle: 2, dot: 2, blackSquare: 1, arc: 1 },
+    opacity: 0.5,
   },
   about: {
     key: 'about',
@@ -60,38 +66,44 @@ export const SECTIONS: Record<string, SectionConfig> = {
     agents: 1,
     palette: { red: 0.2, black: 0.65, cream: 0.15 },
     shapeWeights: { blackSquare: 2, barV: 2, barH: 1, diagonal: 2, dot: 1 },
+    opacity: 0.45,
   },
   skills: {
     key: 'skills',
     background: 'dark',
-    density: 0.4,
+    density: 0.3,
     agents: 1,
-    palette: { red: 0.4, black: 0.1, cream: 0.5 },
-    shapeWeights: { hollowSquare: 3, redSquare: 2, barH: 2, dot: 2, diagonal: 1 },
+    // cream（明るい白枠）は本文の白文字と競合するので重みを下げ、赤を主役に
+    palette: { red: 0.5, black: 0.2, cream: 0.3 },
+    shapeWeights: { hollowSquare: 2, redSquare: 2, barH: 2, dot: 2, diagonal: 1 },
+    opacity: 0.26,
   },
   ai: {
     key: 'ai',
     background: 'light',
-    density: 0.34,
+    density: 0.3,
     agents: 2,
     palette: { red: 0.45, black: 0.4, cream: 0.15 },
     shapeWeights: { redSquare: 2, blackSquare: 2, circle: 2, dot: 2, diagonal: 1 },
+    opacity: 0.4,
   },
   career: {
     key: 'career',
     background: 'dark',
-    density: 0.28,
+    density: 0.26,
     agents: 1,
     palette: { red: 0.6, black: 0.1, cream: 0.3 },
     shapeWeights: { barV: 4, diagonal: 2, dot: 2, redSquare: 1, circle: 1 },
+    opacity: 0.5,
   },
   portfolio: {
     key: 'portfolio',
     background: 'light',
-    density: 0.32,
+    density: 0.3,
     agents: 1,
     palette: { red: 0.3, black: 0.55, cream: 0.15 },
     shapeWeights: { hollowSquare: 3, blackSquare: 1, diagonal: 1, dot: 2, barH: 1 },
+    opacity: 0.4,
   },
   contact: {
     key: 'contact',
@@ -100,6 +112,7 @@ export const SECTIONS: Record<string, SectionConfig> = {
     agents: 0,
     palette: { red: 0.6, black: 0.1, cream: 0.3 },
     shapeWeights: { circle: 3, redSquare: 1, dot: 2 },
+    opacity: 0.55,
   },
 };
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import AnimatedHero from '../components/AnimatedHero';
 import AnimatedSkillBar from '../components/AnimatedSkillBar';
 import FadeIn from '../components/FadeIn';
 import ConstructivistCanvas from '../components/ConstructivistCanvas';
+import ProunCanvas from '../components/ProunCanvas';
 
 interface ZennArticle {
   id: number;
@@ -209,8 +210,8 @@ const projects = [
 
     {/* ═══════════════════ Hero — 構成主義的ヒーロー ═══════════════════ */}
     <section class="relative overflow-hidden bg-constructivist-black min-h-[90vh] flex items-center">
-      {/* 構成主義タイル装飾（Tiled + Phaser） */}
-      <ConstructivistCanvas client:visible section="hero" />
+      {/* El Lissitzky 3D Proun 装飾（Three.js・軸測投影） */}
+      <ProunCanvas client:visible />
 
       <div class="relative z-10 w-full">
         <AnimatedHero


### PR DESCRIPTION
## 背景

モバイルの Skills セクションで、Phaser 装飾タイル（白い中空正方形）が全不透明で本文の白文字に重なり **文字が読めない** 状態だった。加えて、装飾を El Lissitzky の様式（Proun＝軸測投影の浮遊する立体構成）として本格化し **3D オブジェ** を導入したい、という要望。

## 成果（枯れるまで反復）

### 1. 可読性の緊急是正 ✅
- `sections.ts` に装飾レイヤーの `opacity` を追加し canvas host と静的フォールバックへ適用。本文が密なセクションほど後退（skills 0.26 等）。Skills は赤主体へ寄せ密度も低減。
- 393px モバイルで Skills/DB の可読性回復を実機確認。

### 2–5. El Lissitzky 3D Proun（Hero）✅
- **`ProunCanvas.tsx`（Three.js）**: `OrthographicCamera`（軸測・消失点なし）。赤い楔が cream スラブへ対角に切り込む構図＋黒い正方板（cream 稜線）＋円環＋力線、大きな負空間。6〜7 個のフラット色フォーム（`MeshBasicMaterial` で cream が灰色化しない）。緩慢な多軸ドリフト・スクロール非連動。
- **遅延ロード**: `three` は動的 import の別チャンク（〜705kB）、初期バンドル非搭載。
- **可読性最優先**: 背面（z-0・aria-hidden・pointer-events none）、構図は中央右に限定し H1・本文に被せない。**md 未満（モバイル）は装飾非表示**で three も読まずクリーンな大文字タイポ。`prefers-reduced-motion`／WebGL 非対応は **収まりの良い静的 SVG 軸測 Proun**（全面拡大しない）。
- **整理**: `AnimatedHero` の旧 2D Proun（赤ブロック＋円）を削除し装飾を 3D に一本化（avatar フレームは維持）。
- 可視外・タブ非表示で rAF 停止、アンマウントで dispose。

設計の正典: `specs/components/proun-3d.spec.md`（実装メモ＝設計からの確定的逸脱を併記）。

## 検証
- `astro check` 0 errors / `npm run build` 成功 / `three` は別チャンク（遅延ロード）。
- 実機目視（Playwright）: デスクトップ 3D Proun・reduced-motion フォールバック・モバイル（装飾非表示でクリーン）・Skills モバイル可読性回復。

🤖 Generated with [Claude Code](https://claude.com/claude-code)