### PR TITLE
feat(hero): モバイルでも 3D Proun を表示（可読性を保つ上部配置）

### DIFF
--- a/src/components/ProunCanvas.tsx
+++ b/src/components/ProunCanvas.tsx
@@ -81,6 +81,7 @@ function buildSpecs(THREE: typeof THREE_NS): ObjSpec[] {
       rot: [d(8), d(18), d(-48)],
       spin: [0.0, 0.022, 0.01],
       bob: 0.1,
+      mobileDrop: true,
     },
     // D: 黒い正方板（赤の対）— A とは別角度で独立して浮遊（"画面"読みを避ける）。cream 稜線で見せる
     {
@@ -160,7 +161,7 @@ export default function ProunCanvas() {
       const rect = host.getBoundingClientRect();
       let width = Math.max(1, Math.round(rect.width));
       let height = Math.max(1, Math.round(rect.height));
-      const isMobile = width < 480;
+      const isMobile = width < 768;
 
       const scene = new THREE.Scene();
 
@@ -181,7 +182,8 @@ export default function ProunCanvas() {
       let camera = makeCamera(width, height);
 
       const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+      // モバイルは DPR を抑えてバッテリ/負荷を軽減
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, isMobile ? 1.5 : 2));
       renderer.setSize(width, height);
       host.appendChild(renderer.domElement);
 
@@ -189,12 +191,19 @@ export default function ProunCanvas() {
       // 各面を正しい単色にする（Lambert だと陰面が灰色化し cream が濁る）。ライト不要。
       // 軸測（消失点なし）＋オーバーラップ＋傾きで立体を読ませる。
 
-      // Proun を中央右へ寄せ、本文カラム背後（左上）を空ける。
-      // scale を下げて大きな負空間（Proun の主役＝余白）を確保。
+      // 配置: デスクトップは中央右に showpiece。モバイルは本文が縦積みで全幅を使うため、
+      // 構図を上部（極大 H1 周辺）に寄せて説明文の帯を空け、核オブジェのみのコンパクト構図にする。
       const group = new THREE.Group();
-      group.position.set(1.1, 0.6, 0);
-      group.scale.setScalar(0.84);
+      if (isMobile) {
+        group.position.set(-0.5, 2.9, 0);
+        group.scale.setScalar(0.5);
+      } else {
+        group.position.set(1.1, 0.6, 0);
+        group.scale.setScalar(0.84);
+      }
       scene.add(group);
+      // モバイルは H1 近傍に出るため存在感をやや抑える
+      host.style.opacity = String(isMobile ? 0.82 : LAYER_OPACITY);
 
       const geoms: THREE_NS.BufferGeometry[] = [];
       const mats: THREE_NS.Material[] = [];
@@ -308,8 +317,8 @@ export default function ProunCanvas() {
     <div
       ref={hostRef}
       aria-hidden="true"
-      // モバイルでは装飾を非表示（本文の可読性最優先 / three も読まない）。md 以上で showpiece。
-      className="absolute inset-0 overflow-hidden hidden md:block"
+      // 背面装飾。デスクトップは中央右の showpiece、モバイルは上部のコンパクト構図（effect で配置）。
+      className="absolute inset-0 overflow-hidden"
       style={{ opacity: LAYER_OPACITY, pointerEvents: 'none' }}
     >
       {fallback && <ProunFallback />}
@@ -325,7 +334,7 @@ export default function ProunCanvas() {
 function ProunFallback() {
   return (
     <svg
-      className="absolute top-1/2 right-[4%] -translate-y-1/2 w-[48%] sm:w-[44%] max-w-xl"
+      className="absolute right-[3%] top-[9%] w-[58%] sm:top-1/2 sm:-translate-y-1/2 sm:right-[4%] sm:w-[44%] max-w-xl"
       viewBox="0 0 120 92"
       preserveAspectRatio="xMidYMid meet"
       role="presentation"


### PR DESCRIPTION
## 背景

直前の変更でモバイルは 3D Proun を**非表示**にしていた（縦積みの本文と背面装飾が重なり可読性を損なうため）。ユーザー要望「モバイルでも 3D オブジェを見たい」に応えつつ、可読性を犠牲にしない配置で復活させる。

## 変更

`src/components/ProunCanvas.tsx`:
- **モバイル（< md）専用のコンパクト構図**: グループを**上部（極大 H1 周辺）へ持ち上げ**、scale を下げ、**核オブジェのみ**（cream スラブ・赤い楔・cream 稜線の黒い正方板・円環）に限定。縦に伸びる力線/ドット/線は落とす。
- 不透明な H1 が前面に来るので H1 は可読のまま、**縦積みの説明文の帯は空ける**（本文に装飾が被らない）。
- **DPR を 1.5 に制限**（モバイルの負荷/バッテリ軽減）。可視外・タブ非表示で rAF 停止は従来どおり。
- reduced-motion / WebGL 非対応の**静的 SVG フォールバックもモバイルは上部配置**（デスクトップのみ全面寄り）。

デスクトップの showpiece 構図は不変。

## 検証（Playwright 実機目視）
- モバイル 393px: 3D が H1 周辺に表示され、説明文・リンク・avatar は完全に可読。
- reduced-motion モバイル: 静的 SVG が上部に表示、three 未ロード。
- `astro check` 0 errors / build OK / `three` は別チャンク（遅延ロード）維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L21TTbqjpM5jtRVDtzZnTn)_